### PR TITLE
Minor fix in objects dimensions

### DIFF
--- a/parallelogram/parallelogram.py
+++ b/parallelogram/parallelogram.py
@@ -49,23 +49,21 @@ def make_object( x1, y1, max_dim=100 ):
 
 def make_square( x1, y1, max_dim=100 ):
     if max_dim<2: raise ValueError
-    lim = min( [max(x1,y1)+max_dim, 99] )
-    delta = random.randint( max(x1,y1)+1, lim )
+    lim = min( [max(x1,y1)+max_dim, 99-max(x1,y1)] )
+    delta = random.randint( 1, lim )
     x2 = x1+delta
     y2 = y1+delta
     return ( x1, y1, x2, y2 )
 
 def make_long( x1, y1, max_dim=100 ):
     if max_dim<2: raise ValueError
-    # x1,y1 at the edge, impossible to fit long
-    if x1 == 98 and y1 == 98: raise ValueError
-    lim_x2 = min( [x1+max_dim,99] )
-    lim_y2 = min( [y1+max_dim,99] )
-    delta_x = random.randint( x1+1, lim_x2 )
-    delta_y = random.randint( y1+1, lim_y2 )
+    lim_x2 = min( [x1+max_dim,99-x1] )
+    lim_y2 = min( [y1+max_dim,99-y1] )
+    delta_x = random.randint( 1, lim_x2 )
+    delta_y = random.randint( 1, lim_y2 )
     while delta_x == delta_y:
-        delta_x = random.randint( x1+1, lim_x2 )
-        delta_y = random.randint( y1+1, lim_y2 )
+        delta_x = random.randint( 1, lim_x2 )
+        delta_y = random.randint( 1, lim_y2 )
     x2 = x1+delta_x
     y2 = y1+delta_y
     return ( x1, y1, x2, y2 )

--- a/parallelogram/parallelogram.py
+++ b/parallelogram/parallelogram.py
@@ -93,14 +93,7 @@ def make_production_dataset( n ):
     for i in range(0,math.ceil(n/2)):
         x1 = random.randint( 0, 97 )
         y1 = random.randint( 0, 97 )
-        try:
-            o = make_long( x1, y1, 72 )
-        except:
-            # x1,y1 at the edge,
-            # impossible to fit long
-            x1 = random.randint( 0, 90 )
-            y1 = random.randint( 0, 90 )
-            o = make_long( x1, y1 )
+        o = make_long( x1, y1, 72 )
         data.append( o )
     for i in range(0,math.ceil(n/2)):
         x1 = random.randint( 0, 98 )


### PR DESCRIPTION
We've refined the **make_square** and **make_long** functions to address a potential issue where generated shapes could exceed the specified max_dim limit along the x or y axis.

1. In the make_square function, we've adjusted the calculation of the upper limit (lim) for the random delta to ensure that the generated square stays within the specified max_dim along either the x or y axis.

2. Similarly in the make_long function, we've adjusted the calculation of lim_x2 and lim_y2 to prevent the generated long shape from exceeding the specified max_dim along either the x or y axis.

Closes #23 